### PR TITLE
feat: enable cross-workspace definition lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [Unreleased]
+- Enhancements
+  - Allow configuring cross-workspace Go to Definition lookups via `objectscript.export.searchOtherWorkspaceFolders` so local sources in sibling workspace folders are resolved before falling back to the server.
+
 ## [3.0.6] 09-Sep-2025
 - Enhancements
   - Add `objectscript.unitTest.enabled` setting (#1627)

--- a/README.md
+++ b/README.md
@@ -48,28 +48,50 @@ Open VS Code. Go to Extensions view (<kbd>⌘</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</
 This extension is able to to take advantage of some VS Code APIs that have not yet been finalized.
 
 The additional features (and the APIs used) are:
+
 - Server-side [searching across files](https://code.visualstudio.com/docs/editor/codebasics#_search-across-files) being accessed using isfs (_TextSearchProvider_)
 - [Quick Open](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_quick-open) of isfs files (_FileSearchProvider_).
 
 To unlock these features (optional):
 
 1. Download and install a beta version from GitHub. This is necessary because Marketplace does not allow publication of extensions that use proposed APIs.
-	- Go to https://github.com/intersystems-community/vscode-objectscript/releases
-	- Locate the beta immediately above the release you installed from Marketplace. For instance, if you installed `3.0.6`, look for `3.0.7-beta.1`. This will be functionally identical to the Marketplace version apart from being able to use proposed APIs.
-	- Download the VSIX file (for example `vscode-objectscript-3.0.7-beta.1.vsix`) and install it. One way to install a VSIX is to drag it from your download folder and drop it onto the list of extensions in the Extensions view of VS Code.
+
+   - Go to https://github.com/intersystems-community/vscode-objectscript/releases
+   - Locate the beta immediately above the release you installed from Marketplace. For instance, if you installed `3.0.6`, look for `3.0.7-beta.1`. This will be functionally identical to the Marketplace version apart from being able to use proposed APIs.
+   - Download the VSIX file (for example `vscode-objectscript-3.0.7-beta.1.vsix`) and install it. One way to install a VSIX is to drag it from your download folder and drop it onto the list of extensions in the Extensions view of VS Code.
 
 2. From [Command Palette](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_command-palette) choose `Preferences: Configure Runtime Arguments`.
 3. In the argv.json file that opens, add this line (required for both Stable and Insiders versions of VS Code):
+
 ```json
 "enable-proposed-api": ["intersystems-community.vscode-objectscript"]
 ```
+
 4. Exit VS Code and relaunch it.
 5. Verify that the ObjectScript channel of the Output panel reports this:
+
 ```
 intersystems-community.vscode-objectscript version X.Y.Z-beta.1 activating with proposed APIs available.
 ```
 
 After a subsequent update of the extension from Marketplace you will only have to download and install the new `vscode-objectscript-X.Y.Z-beta.1` VSIX. None of the other steps above are needed again.
+
+## Cross-workspace Go to Definition
+
+> **Implementation developed and maintained by Consistem Sistemas**
+
+When working in a multi-root workspace, the extension normally searches the current workspace folder (and any sibling folders connected to the same namespace) for local copies of ObjectScript code before requesting the server version. If you keep shared source code in other workspace folders with different connection settings, set the `objectscript.export.searchOtherWorkspaceFolders` array in the consuming folder's settings so those folders are considered first. Use workspace-folder names, or specify `"*"` to search every non-`isfs` folder.
+
+```json
+{
+  "objectscript.export": {
+    "folder": "src",
+    "searchOtherWorkspaceFolders": ["shared"]
+  }
+}
+```
+
+With this setting enabled, features such as Go to Definition resolve to the first matching local file across the configured workspace folders before falling back to the server copy.
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -1396,6 +1396,14 @@
               },
               "additionalProperties": false
             },
+            "searchOtherWorkspaceFolders": {
+              "markdownDescription": "Additional workspace folders to search for client-side sources when resolving ObjectScript documents. Specify `\"*\"` to search all non-isfs workspace folders in the current multi-root workspace before falling back to the server.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": []
+            },
             "atelier": {
               "description": "Export source code as Atelier did it, with packages as subfolders. This setting only affects classes, routines, include files and DFI files.",
               "type": "boolean"

--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -165,30 +165,73 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
         });
       }
     } else {
-      const conn = config("conn", workspaceFolder);
+      const conn = config("conn", workspaceFolder) ?? {};
+      const exportConfig =
+        workspaceFolder && workspaceFolder !== ""
+          ? (config("export", workspaceFolder) as { searchOtherWorkspaceFolders?: string[] })
+          : undefined;
+      const searchOtherWorkspaceFolders = Array.isArray(exportConfig?.searchOtherWorkspaceFolders)
+        ? exportConfig.searchOtherWorkspaceFolders
+            .map((value) => (typeof value === "string" ? value.trim() : ""))
+            .filter((value) => value.length > 0)
+        : [];
+      const includeAllFolders = searchOtherWorkspaceFolders.includes("*");
+      const explicitAdditionalFolders = new Set(
+        searchOtherWorkspaceFolders.filter((value) => value !== "*").map((value) => value.toLowerCase())
+      );
       if (!forceServerCopy) {
-        // Look for the document in the local file system
-        const localFile = this.findLocalUri(name, workspaceFolder);
-        if (localFile && (!namespace || namespace === conn.ns)) {
-          // Exists as a local file and we aren't viewing a different namespace on the same server,
-          // so return a uri that will open the local file.
+        const tryLocalUri = (folderName: string, allowNamespaceMismatch: boolean): vscode.Uri => {
+          const localFile = this.findLocalUri(name, folderName);
+          if (!localFile) return;
+          if (!allowNamespaceMismatch && namespace) {
+            const folderConn = config("conn", folderName) ?? {};
+            if (folderConn.ns && namespace !== folderConn.ns) {
+              return;
+            }
+          }
           return localFile;
-        } else {
-          // The local file doesn't exist in this folder, so check any other
-          // local folders in this workspace if it's a multi-root workspace
-          const wFolders = vscode.workspace.workspaceFolders;
-          if (wFolders && wFolders.length > 1) {
-            // This is a multi-root workspace
+        };
+
+        // Look for the document in the local file system
+        const primaryLocal = tryLocalUri(workspaceFolder, false);
+        if (primaryLocal) {
+          return primaryLocal;
+        }
+
+        // Check any other eligible local folders in this workspace if it's a multi-root workspace
+        const wFolders = vscode.workspace.workspaceFolders;
+        if (wFolders && wFolders.length > 1 && workspaceFolder) {
+          const candidates: { folder: vscode.WorkspaceFolder; allowNamespaceMismatch: boolean }[] = [];
+          const seen = new Set<string>();
+          const addCandidate = (folder: vscode.WorkspaceFolder, allowNamespaceMismatch: boolean): void => {
+            if (!notIsfs(folder.uri)) return;
+            if (folder.name === workspaceFolder) return;
+            if (seen.has(folder.name)) return;
+            candidates.push({ folder, allowNamespaceMismatch });
+            seen.add(folder.name);
+          };
+
+          for (const wFolder of wFolders) {
+            if (wFolder.name === workspaceFolder) continue;
+            const wFolderConn = config("conn", wFolder.name) ?? {};
+            if (compareConns(conn, wFolderConn) && (!namespace || namespace === wFolderConn.ns)) {
+              addCandidate(wFolder, false);
+            }
+          }
+
+          if (includeAllFolders || explicitAdditionalFolders.size > 0) {
             for (const wFolder of wFolders) {
-              if (notIsfs(wFolder.uri) && wFolder.name != workspaceFolder) {
-                // This isn't the folder that we checked originally
-                const wFolderConn = config("conn", wFolder.name);
-                if (compareConns(conn, wFolderConn) && (!namespace || namespace === wFolderConn.ns)) {
-                  // This folder is connected to the same server:ns combination as the original folder
-                  const wFolderFile = this.findLocalUri(name, wFolder.name);
-                  if (wFolderFile) return wFolderFile;
-                }
-              }
+              if (wFolder.name === workspaceFolder) continue;
+              const shouldInclude = includeAllFolders || explicitAdditionalFolders.has(wFolder.name.toLowerCase());
+              if (!shouldInclude) continue;
+              addCandidate(wFolder, true);
+            }
+          }
+
+          for (const candidate of candidates) {
+            const candidateLocal = tryLocalUri(candidate.folder.name, candidate.allowNamespaceMismatch);
+            if (candidateLocal) {
+              return candidateLocal;
             }
           }
         }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,25 +1,99 @@
 import * as assert from "assert";
 import { before } from "mocha";
+import * as path from "path";
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
-import { window, extensions } from "vscode";
-import { extensionId, smExtensionId } from "../../extension";
+import * as vscode from "vscode";
+import { extensionId, smExtensionId, OBJECTSCRIPT_FILE_SCHEMA } from "../../extension";
+import { getUrisForDocument } from "../../utils/documentIndex";
+
+async function waitForIndexedDocument(documentName: string, workspaceFolderName: string): Promise<void> {
+  const workspaceFolder = vscode.workspace.workspaceFolders?.find((wf) => wf.name === workspaceFolderName);
+  assert.ok(workspaceFolder, `Workspace folder '${workspaceFolderName}' was not found.`);
+  const start = Date.now();
+  while (Date.now() - start < 10000) {
+    if (getUrisForDocument(documentName, workspaceFolder).length > 0) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.fail(`Timed out waiting for '${documentName}' to be indexed in workspace folder '${workspaceFolderName}'.`);
+}
+
+function getDefinitionTargets(definitions: (vscode.Location | vscode.DefinitionLink)[]): vscode.Uri[] {
+  return definitions
+    .map((definition) => ("targetUri" in definition ? definition.targetUri : definition.uri))
+    .filter((uri): uri is vscode.Uri => !!uri);
+}
 
 suite("Extension Test Suite", () => {
   suiteSetup(async function () {
     // make sure extension is activated
-    const serverManager = extensions.getExtension(smExtensionId);
+    const serverManager = vscode.extensions.getExtension(smExtensionId);
     await serverManager?.activate();
-    const ext = extensions.getExtension(extensionId);
+    const ext = vscode.extensions.getExtension(extensionId);
     await ext?.activate();
   });
 
   before(() => {
-    window.showInformationMessage("Start all tests.");
+    vscode.window.showInformationMessage("Start all tests.");
   });
 
   test("Sample test", () => {
     assert.ok("All good");
+  });
+
+  test("Go to Definition resolves to sibling workspace folder", async function () {
+    this.timeout(10000);
+    await waitForIndexedDocument("MultiRoot.Shared.cls", "shared");
+    const clientFolder = vscode.workspace.workspaceFolders?.find((wf) => wf.name === "client");
+    assert.ok(clientFolder, "Client workspace folder not available.");
+    const callerUri = vscode.Uri.joinPath(clientFolder.uri, "src", "MultiRoot", "Caller.cls");
+    const document = await vscode.workspace.openTextDocument(callerUri);
+    await vscode.window.showTextDocument(document);
+
+    const target = "MultiRoot.Shared";
+    const sharedOffset = document.getText().indexOf(target);
+    assert.notStrictEqual(sharedOffset, -1, "Shared class reference not found in Caller.cls");
+    const position = document.positionAt(sharedOffset + target.indexOf("Shared") + 1);
+    const definitions = (await vscode.commands.executeCommand(
+      "vscode.executeDefinitionProvider",
+      callerUri,
+      position
+    )) as (vscode.Location | vscode.DefinitionLink)[];
+    assert.ok(definitions?.length, "Expected at least one definition result");
+    const targetUris = getDefinitionTargets(definitions);
+    const sharedTargetSuffix = path.join("shared", "src", "MultiRoot", "Shared.cls");
+    assert.ok(
+      targetUris.some((uri) => uri.scheme === "file" && uri.fsPath.endsWith(sharedTargetSuffix)),
+      "Expected Go to Definition to resolve to the shared workspace folder"
+    );
+  });
+
+  test("Go to Definition falls back to server URI when local copy missing", async function () {
+    this.timeout(10000);
+    await waitForIndexedDocument("MultiRoot.Shared.cls", "shared");
+    const clientFolder = vscode.workspace.workspaceFolders?.find((wf) => wf.name === "client");
+    assert.ok(clientFolder, "Client workspace folder not available.");
+    const callerUri = vscode.Uri.joinPath(clientFolder.uri, "src", "MultiRoot", "Caller.cls");
+    const document = await vscode.workspace.openTextDocument(callerUri);
+    await vscode.window.showTextDocument(document);
+
+    const target = "MultiRoot.ServerOnly";
+    const offset = document.getText().indexOf(target);
+    assert.notStrictEqual(offset, -1, "Server-only class reference not found in Caller.cls");
+    const position = document.positionAt(offset + target.indexOf("ServerOnly") + 1);
+    const definitions = (await vscode.commands.executeCommand(
+      "vscode.executeDefinitionProvider",
+      callerUri,
+      position
+    )) as (vscode.Location | vscode.DefinitionLink)[];
+    assert.ok(definitions?.length, "Expected definition result when resolving missing class");
+    const targetUris = getDefinitionTargets(definitions);
+    assert.ok(
+      targetUris.some((uri) => uri.scheme === OBJECTSCRIPT_FILE_SCHEMA),
+      "Expected Go to Definition to return a server URI when no local copy exists"
+    );
   });
 });

--- a/test-fixtures/multi-root/client/.vscode/settings.json
+++ b/test-fixtures/multi-root/client/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "objectscript.conn": {
+    "active": true,
+    "ns": "USER"
+  },
+  "objectscript.export": {
+    "folder": "src",
+    "searchOtherWorkspaceFolders": [
+      "shared"
+    ]
+  }
+}

--- a/test-fixtures/multi-root/client/src/MultiRoot/Caller.cls
+++ b/test-fixtures/multi-root/client/src/MultiRoot/Caller.cls
@@ -1,0 +1,10 @@
+Class MultiRoot.Caller Extends %RegisteredObject
+{
+
+ClassMethod Test()
+{
+    Do ##class(MultiRoot.Shared).Ping()
+    Do ##class(MultiRoot.ServerOnly).Ping()
+}
+
+}

--- a/test-fixtures/multi-root/shared/.vscode/settings.json
+++ b/test-fixtures/multi-root/shared/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "objectscript.conn": {
+    "active": false,
+    "ns": "SAMPLES"
+  },
+  "objectscript.export": {
+    "folder": "src"
+  }
+}

--- a/test-fixtures/multi-root/shared/src/MultiRoot/Shared.cls
+++ b/test-fixtures/multi-root/shared/src/MultiRoot/Shared.cls
@@ -1,0 +1,9 @@
+Class MultiRoot.Shared Extends %RegisteredObject
+{
+
+ClassMethod Ping()
+{
+    Quit
+}
+
+}

--- a/test-fixtures/test.code-workspace
+++ b/test-fixtures/test.code-workspace
@@ -1,15 +1,19 @@
 {
   "folders": [
     {
-      "path": "."
+      "name": "client",
+      "path": "multi-root/client"
     },
+    {
+      "name": "shared",
+      "path": "multi-root/shared"
+    }
   ],
   "settings": {
     "objectscript.conn": {
       "active": false
     },
     "objectscript.ignoreInstallServerManager": true,
-    "intersystems.servers": {
-    }
+    "intersystems.servers": {}
   }
 }


### PR DESCRIPTION
- Habilita Go to Definition entre pastas de um multi-root workspace (ex.: DESENV7* ↔ COMP-7.0), preferindo **arquivo local** antes do servidor.
- `DocumentContentProvider.getUri`: busca em pastas irmãs do workspace.
- Nova setting: `objectscript.export.searchOtherWorkspaceFolders` (lista de folders ou `"*"`).
- README/schema atualizados.
- Testes de integração para resolução local e fallback.