### PR TITLE
Chore API restructure to use request util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Add ObjectScript enter rules for semicolon (`;`) continuation on line break. (#5)
   - Auto-indent dot syntax on Enter for `objectscript`/`objectscript-int` (replicates leading dots). (#6)
   - Added `resolveContextExpression` command: posts current line/routine to API, inserts returned code on success, shows error otherwise. (#7)
+  - Refactor API: extracted request util and updated endpoints (#8)
 
 ## [3.0.6] 09-Sep-2025
 

--- a/src/api/ccs/sourceControl.ts
+++ b/src/api/ccs/sourceControl.ts
@@ -1,0 +1,53 @@
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
+import * as https from "https";
+import * as vscode from "vscode";
+
+import { AtelierAPI } from "../";
+
+export class SourceControlApi {
+  private readonly client: AxiosInstance;
+
+  private constructor(client: AxiosInstance) {
+    this.client = client;
+  }
+
+  public static fromAtelierApi(api: AtelierAPI): SourceControlApi {
+    const { host, port, username, password, https: useHttps, pathPrefix } = api.config;
+
+    if (!host || !port) {
+      throw new Error("No active InterSystems server connection for this file.");
+    }
+
+    const normalizedPrefix = pathPrefix ? (pathPrefix.startsWith("/") ? pathPrefix : `/${pathPrefix}`) : "";
+    const baseUrl = `${useHttps ? "https" : "http"}://${host}:${port}${encodeURI(normalizedPrefix)}`;
+
+    const httpsAgent = new https.Agent({
+      rejectUnauthorized: vscode.workspace.getConfiguration("http").get("proxyStrictSSL"),
+    });
+
+    const client = axios.create({
+      baseURL: `${baseUrl}/api/sourcecontrol/vscode`,
+      headers: {
+        "Content-Type": "application/json",
+      },
+      httpsAgent,
+      auth:
+        typeof username === "string" && typeof password === "string"
+          ? {
+              username,
+              password,
+            }
+          : undefined,
+    });
+
+    return new SourceControlApi(client);
+  }
+
+  public post<T = unknown, R = AxiosResponse<T>>(
+    endpoint: string,
+    data?: unknown,
+    config?: AxiosRequestConfig<unknown>
+  ): Promise<R> {
+    return this.client.post<T, R>(endpoint, data, config);
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -162,7 +162,7 @@ import {
 import { WorkspaceNode, NodeBase } from "./explorer/nodes";
 import { showPlanWebview } from "./commands/showPlanPanel";
 import { isfsConfig } from "./utils/FileProviderUtil";
-import { resolveContextExpression } from "./commands/contextHelp";
+import { resolveContextExpression } from "./commands/ccs/contextHelp";
 
 const packageJson = vscode.extensions.getExtension(extensionId).packageJSON;
 const extensionVersion = packageJson.version;


### PR DESCRIPTION
Refactored code to improve organization:
- Request sending function moved to `api/ccs/`
- Endpoint structure adjusted to `commands/ccs/`
