### PR TITLE
Reorganize module structure

### DIFF
--- a/src/ccs/commands/contextHelp.ts
+++ b/src/ccs/commands/contextHelp.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
 
-import { ContextExpressionClient } from "../sourcecontrol/contextExpressionClient";
+import { ContextExpressionClient } from "../sourcecontrol/clients/contextExpressionClient";
 import { handleError } from "../../utils";
 
 const sharedClient = new ContextExpressionClient();

--- a/src/ccs/commands/contextHelp.ts
+++ b/src/ccs/commands/contextHelp.ts
@@ -2,8 +2,8 @@ import * as path from "path";
 import * as vscode from "vscode";
 
 import { AtelierAPI } from "../../api";
-import { SourceControlApi } from "../../api/ccs/sourceControl";
 import { handleError } from "../../utils";
+import { SourceControlApi } from "../sourcecontrol/client";
 
 interface ResolveContextExpressionResponse {
   status?: string;

--- a/src/ccs/commands/contextHelp.ts
+++ b/src/ccs/commands/contextHelp.ts
@@ -1,15 +1,10 @@
 import * as path from "path";
 import * as vscode from "vscode";
 
-import { AtelierAPI } from "../../api";
+import { ContextExpressionClient } from "../sourcecontrol/contextExpressionClient";
 import { handleError } from "../../utils";
-import { SourceControlApi } from "../sourcecontrol/client";
 
-interface ResolveContextExpressionResponse {
-  status?: string;
-  textExpression?: string;
-  message?: string;
-}
+const sharedClient = new ContextExpressionClient();
 
 export async function resolveContextExpression(): Promise<void> {
   const editor = vscode.window.activeTextEditor;
@@ -28,23 +23,11 @@ export async function resolveContextExpression(): Promise<void> {
   }
 
   const routine = path.basename(document.fileName);
-  const api = new AtelierAPI(document.uri);
-
-  let sourceControlApi: SourceControlApi;
-  try {
-    sourceControlApi = SourceControlApi.fromAtelierApi(api);
-  } catch (error) {
-    void vscode.window.showErrorMessage(error instanceof Error ? error.message : String(error));
-    return;
-  }
 
   try {
-    const response = await sourceControlApi.post<ResolveContextExpressionResponse>("/resolveContextExpression", {
-      routine,
-      contextExpression,
-    });
+    const response = await sharedClient.resolve(document, { routine, contextExpression });
+    const data = response ?? {};
 
-    const data = response.data ?? {};
     if (typeof data.status === "string" && data.status.toLowerCase() === "success" && data.textExpression) {
       const eol = document.eol === vscode.EndOfLine.CRLF ? "\r\n" : "\n";
       const textExpression = data.textExpression.replace(/\r?\n/g, eol);

--- a/src/ccs/config/schema.md
+++ b/src/ccs/config/schema.md
@@ -1,0 +1,13 @@
+# Configuração do módulo CCS
+
+As opções abaixo ficam no escopo `objectscript.ccs` e controlam as integrações específicas
+para o fork da Consistem.
+
+| Chave            | Tipo                      | Padrão      | Descrição                                                                                                       |
+| ---------------- | ------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------- |
+| `endpoint`       | `string`                  | `undefined` | URL base alternativa para a API. Se não definida, a URL é derivada da conexão ativa do Atelier.                 |
+| `requestTimeout` | `number`                  | `500`       | Tempo limite (ms) aplicado às chamadas HTTP do módulo. Valores menores ou inválidos são normalizados para zero. |
+| `debugLogging`   | `boolean`                 | `false`     | Quando verdadeiro, registra mensagens detalhadas no `ObjectScript` Output Channel.                              |
+| `flags`          | `Record<string, boolean>` | `{}`        | Feature flags opcionais que podem ser lidas pelas features do módulo.                                           |
+
+Essas configurações não exigem reload da janela; toda leitura é feita sob demanda.

--- a/src/ccs/config/settings.ts
+++ b/src/ccs/config/settings.ts
@@ -1,0 +1,51 @@
+import * as vscode from "vscode";
+
+export interface CcsSettings {
+  endpoint?: string;
+  requestTimeout: number;
+  debugLogging: boolean;
+  flags: Record<string, boolean>;
+}
+
+const CCS_CONFIGURATION_SECTION = "objectscript.ccs";
+const DEFAULT_TIMEOUT = 500;
+
+export function getCcsSettings(): CcsSettings {
+  const configuration = vscode.workspace.getConfiguration(CCS_CONFIGURATION_SECTION);
+  const endpoint = sanitizeEndpoint(configuration.get<string | undefined>("endpoint"));
+  const requestTimeout = coerceTimeout(configuration.get<number | undefined>("requestTimeout"));
+  const debugLogging = Boolean(configuration.get<boolean | undefined>("debugLogging"));
+  const flags = configuration.get<Record<string, boolean>>("flags") ?? {};
+
+  return {
+    endpoint,
+    requestTimeout,
+    debugLogging,
+    flags,
+  };
+}
+
+export function isFlagEnabled(flag: string, settings: CcsSettings = getCcsSettings()): boolean {
+  return Boolean(settings.flags?.[flag]);
+}
+
+function sanitizeEndpoint(endpoint?: string): string | undefined {
+  if (!endpoint) {
+    return undefined;
+  }
+
+  const trimmed = endpoint.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  return trimmed.replace(/\/+$/, "");
+}
+
+function coerceTimeout(timeout: number | undefined): number {
+  if (typeof timeout !== "number" || Number.isNaN(timeout)) {
+    return DEFAULT_TIMEOUT;
+  }
+
+  return Math.max(0, Math.floor(timeout));
+}

--- a/src/ccs/core/http.ts
+++ b/src/ccs/core/http.ts
@@ -1,0 +1,81 @@
+import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, InternalAxiosRequestConfig } from "axios";
+import * as https from "https";
+import * as vscode from "vscode";
+
+import { logDebug, logError } from "./logging";
+import { getCcsSettings } from "../config/settings";
+
+interface CreateClientOptions {
+  baseURL: string;
+  auth?: AxiosRequestConfig["auth"];
+  defaultTimeout?: number;
+}
+
+export function createHttpClient(options: CreateClientOptions): AxiosInstance {
+  const { baseURL, auth, defaultTimeout } = options;
+  const strictSSL = vscode.workspace.getConfiguration("http").get<boolean>("proxyStrictSSL");
+  const httpsAgent = new https.Agent({ rejectUnauthorized: strictSSL });
+  const timeout = typeof defaultTimeout === "number" ? defaultTimeout : getCcsSettings().requestTimeout;
+
+  const client = axios.create({
+    baseURL,
+    auth,
+    timeout,
+    headers: { "Content-Type": "application/json" },
+    httpsAgent,
+  });
+
+  attachLogging(client);
+
+  return client;
+}
+
+function attachLogging(client: AxiosInstance): void {
+  client.interceptors.request.use((config) => {
+    logDebug(`HTTP ${config.method?.toUpperCase()} ${resolveFullUrl(client, config)}`);
+    return config;
+  });
+
+  client.interceptors.response.use(
+    (response) => {
+      logDebug(`HTTP ${response.status} ${resolveFullUrl(client, response.config)}`);
+      return response;
+    },
+    (error: AxiosError) => {
+      if (axios.isCancel(error)) {
+        logDebug("HTTP request cancelled");
+        return Promise.reject(error);
+      }
+
+      const status = error.response?.status;
+      const url = resolveFullUrl(client, error.config ?? {});
+      const message = typeof status === "number" ? `HTTP ${status} ${url}` : `HTTP request failed ${url}`;
+      logError(message, error);
+      return Promise.reject(error);
+    }
+  );
+}
+
+function resolveFullUrl(client: AxiosInstance, config: AxiosRequestConfig | InternalAxiosRequestConfig): string {
+  const base = config.baseURL ?? client.defaults.baseURL ?? "";
+  const url = config.url ?? "";
+  if (!base) {
+    return url;
+  }
+
+  if (/^https?:/i.test(url)) {
+    return url;
+  }
+
+  return `${base}${url}`;
+}
+
+export function createAbortSignal(token: vscode.CancellationToken): { signal: AbortSignal; dispose: () => void } {
+  const controller = new AbortController();
+  const subscription = token.onCancellationRequested(() => controller.abort());
+
+  return {
+    signal: controller.signal,
+    dispose: () => subscription.dispose(),
+  };
+}

--- a/src/ccs/core/logging.ts
+++ b/src/ccs/core/logging.ts
@@ -1,0 +1,52 @@
+import { inspect } from "util";
+
+import { outputChannel } from "../../utils";
+import { getCcsSettings } from "../config/settings";
+
+type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
+
+const PREFIX = "[CCS]";
+
+export function logDebug(message: string, ...details: unknown[]): void {
+  if (!getCcsSettings().debugLogging) {
+    return;
+  }
+  writeLog("DEBUG", message, details);
+}
+
+export function logInfo(message: string, ...details: unknown[]): void {
+  writeLog("INFO", message, details);
+}
+
+export function logWarn(message: string, ...details: unknown[]): void {
+  writeLog("WARN", message, details);
+}
+
+export function logError(message: string, error?: unknown): void {
+  const details = error ? [formatError(error)] : [];
+  writeLog("ERROR", message, details);
+}
+
+function writeLog(level: LogLevel, message: string, details: unknown[]): void {
+  const timestamp = new Date().toISOString();
+  outputChannel.appendLine(`${PREFIX} ${timestamp} ${level}: ${message}`);
+  if (details.length > 0) {
+    for (const detail of details) {
+      outputChannel.appendLine(`${PREFIX}   ${stringify(detail)}`);
+    }
+  }
+}
+
+function stringify(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  return inspect(value, { depth: 4, breakLength: Infinity });
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}${error.stack ? `\n${error.stack}` : ""}`;
+  }
+  return stringify(error);
+}

--- a/src/ccs/core/types.ts
+++ b/src/ccs/core/types.ts
@@ -1,0 +1,10 @@
+export interface ResolveContextExpressionResponse {
+  status?: string;
+  textExpression?: string;
+  message?: string;
+}
+
+export interface SourceControlError {
+  message: string;
+  cause?: unknown;
+}

--- a/src/ccs/index.ts
+++ b/src/ccs/index.ts
@@ -1,0 +1,2 @@
+export { SourceControlApi } from "./sourcecontrol/client";
+export { resolveContextExpression } from "./commands/contextHelp";

--- a/src/ccs/index.ts
+++ b/src/ccs/index.ts
@@ -2,4 +2,4 @@ export { getCcsSettings, isFlagEnabled, type CcsSettings } from "./config/settin
 export { logDebug, logError, logInfo, logWarn } from "./core/logging";
 export { SourceControlApi } from "./sourcecontrol/client";
 export { resolveContextExpression } from "./commands/contextHelp";
-export { ContextExpressionClient } from "./sourcecontrol/contextExpressionClient";
+export { ContextExpressionClient } from "./sourcecontrol/clients/contextExpressionClient";

--- a/src/ccs/index.ts
+++ b/src/ccs/index.ts
@@ -1,2 +1,5 @@
+export { getCcsSettings, isFlagEnabled, type CcsSettings } from "./config/settings";
+export { logDebug, logError, logInfo, logWarn } from "./core/logging";
 export { SourceControlApi } from "./sourcecontrol/client";
 export { resolveContextExpression } from "./commands/contextHelp";
+export { ContextExpressionClient } from "./sourcecontrol/contextExpressionClient";

--- a/src/ccs/sourcecontrol/client.ts
+++ b/src/ccs/sourcecontrol/client.ts
@@ -1,8 +1,7 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 import * as https from "https";
 import * as vscode from "vscode";
-
-import { AtelierAPI } from "../";
+import { AtelierAPI } from "../../api";
 
 export class SourceControlApi {
   private readonly client: AxiosInstance;

--- a/src/ccs/sourcecontrol/clients/contextExpressionClient.ts
+++ b/src/ccs/sourcecontrol/clients/contextExpressionClient.ts
@@ -1,11 +1,11 @@
 import * as vscode from "vscode";
 
-import { AtelierAPI } from "../../api";
-import { getCcsSettings } from "../config/settings";
-import { logDebug } from "../core/logging";
-import { ResolveContextExpressionResponse } from "../core/types";
-import { SourceControlApi } from "./client";
-import { ROUTES } from "./routes";
+import { AtelierAPI } from "../../../api";
+import { getCcsSettings } from "../../config/settings";
+import { logDebug } from "../../core/logging";
+import { ResolveContextExpressionResponse } from "../../core/types";
+import { SourceControlApi } from "../client";
+import { ROUTES } from "../routes";
 
 interface ResolveContextExpressionPayload {
   routine: string;

--- a/src/ccs/sourcecontrol/contextExpressionClient.ts
+++ b/src/ccs/sourcecontrol/contextExpressionClient.ts
@@ -1,0 +1,54 @@
+import * as vscode from "vscode";
+
+import { AtelierAPI } from "../../api";
+import { getCcsSettings } from "../config/settings";
+import { logDebug } from "../core/logging";
+import { ResolveContextExpressionResponse } from "../core/types";
+import { SourceControlApi } from "./client";
+import { ROUTES } from "./routes";
+
+interface ResolveContextExpressionPayload {
+  routine: string;
+  contextExpression: string;
+}
+
+export class ContextExpressionClient {
+  private readonly apiFactory: (api: AtelierAPI) => SourceControlApi;
+
+  public constructor(apiFactory: (api: AtelierAPI) => SourceControlApi = SourceControlApi.fromAtelierApi) {
+    this.apiFactory = apiFactory;
+  }
+
+  public async resolve(
+    document: vscode.TextDocument,
+    payload: ResolveContextExpressionPayload
+  ): Promise<ResolveContextExpressionResponse> {
+    const api = new AtelierAPI(document.uri);
+
+    let sourceControlApi: SourceControlApi;
+    try {
+      sourceControlApi = this.apiFactory(api);
+    } catch (error) {
+      logDebug("Failed to create SourceControl API client for context expression", error);
+      throw error;
+    }
+
+    const { requestTimeout } = getCcsSettings();
+
+    try {
+      const response = await sourceControlApi.post<ResolveContextExpressionResponse>(
+        ROUTES.resolveContextExpression(),
+        payload,
+        {
+          timeout: requestTimeout,
+          validateStatus: (status) => status >= 200 && status < 300,
+        }
+      );
+
+      return response.data ?? {};
+    } catch (error) {
+      logDebug("Context expression resolution failed", error);
+      throw error;
+    }
+  }
+}

--- a/src/ccs/sourcecontrol/routes.ts
+++ b/src/ccs/sourcecontrol/routes.ts
@@ -1,0 +1,7 @@
+export const BASE_PATH = "/api/sourcecontrol/vscode" as const;
+
+export const ROUTES = {
+  resolveContextExpression: () => `/resolveContextExpression`,
+} as const;
+
+export type RouteKey = keyof typeof ROUTES;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -162,7 +162,7 @@ import {
 import { WorkspaceNode, NodeBase } from "./explorer/nodes";
 import { showPlanWebview } from "./commands/showPlanPanel";
 import { isfsConfig } from "./utils/FileProviderUtil";
-import { resolveContextExpression } from "./commands/ccs/contextHelp";
+import { resolveContextExpression } from "./ccs";
 
 const packageJson = vscode.extensions.getExtension(extensionId).packageJSON;
 const extensionVersion = packageJson.version;


### PR DESCRIPTION
## Refactor: CCS structure

### Summary
This PR reorganizes the CCS module to improve clarity, scalability, and maintainability.

### Changes
- Moved CCS-related code into a dedicated `src/ccs/` folder.
- Introduced clear separation of concerns:
  - `config/` → settings reader and schema docs
  - `core/` → HTTP client, logging, shared types
  - `sourcecontrol/` → REST API clients and routes
  - `commands/` → editor commands (e.g., Go to Definition, Context Help)
- Added barrel `index.ts` to expose the public CCS surface.

### Motivation
- Centralize all CCS-specific logic under one module.
- Provide a foundation for adding new endpoints/features without mixing concerns.
- Make onboarding easier by having a documented schema and consistent layout.