### PR TITLE
Fix prevent unwanted semicolon insertion

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1098,6 +1098,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         }
 
         const newLine = event.document.lineAt(newLineNumber);
+        if (newLine.text.trim().length > 0) {
+          continue;
+        }
         if (newLine.text.startsWith(insertText)) {
           continue;
         }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -91,6 +91,22 @@ suite("Extension Test Suite", () => {
     }
   });
 
+  test("Moving lines across dot-prefixed semicolon comments doesn't add semicolons", async () => {
+    const document = await vscode.workspace.openTextDocument({
+      language: "objectscript",
+      content: "  . Do ##class(Test).Run()\n  . ; Comment",
+    });
+    const editor = await vscode.window.showTextDocument(document);
+    try {
+      editor.selection = new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0));
+      await vscode.commands.executeCommand("editor.action.moveLinesDownAction");
+      const expectedText = "  . ; Comment\n  . Do ##class(Test).Run()";
+      await waitForCondition(() => document.getText() === expectedText);
+      assert.strictEqual(document.getText(), expectedText);
+    } finally {
+      await vscode.commands.executeCommand("workbench.action.closeActiveEditor");
+    }
+  });
   test("Go to Definition resolves to sibling workspace folder", async function () {
     this.timeout(10000);
     await waitForIndexedDocument("MultiRoot.Shared.cls", "shared");


### PR DESCRIPTION
Fix unwanted semicolon insertion in ObjectScript dot-prefixed blocks: auto-continuation now inserts the copied prefix only when the target line is empty and preserves `;` only if it existed on the previous line, and a regression test ensures moving lines across dot-prefixed semicolon comments does not inject semicolons.