### PR TITLE
Ensure CCS-first definition provider handles LS fallback

### DIFF
--- a/src/ccs/core/types.ts
+++ b/src/ccs/core/types.ts
@@ -3,7 +3,7 @@ export interface LocationJSON {
   line?: number;
 }
 
-export interface ResolveDefinitionResponse extends LocationJSON {}
+export type ResolveDefinitionResponse = LocationJSON;
 
 export interface ResolveContextExpressionResponse {
   status?: string;


### PR DESCRIPTION
## Summary
- register the CCS-first definition provider regardless of Language Server availability and delegate to the native provider only when needed
- allow the prioritized definition provider to run without a delegate, add optional debug logging, and keep single-location responses from CCS
- tidy the CCS resolve response typing to satisfy lint checks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfc195a59883208c7d77f94d47fbd7