### PR TITLE
Fix/context help identation

### DIFF
--- a/src/ccs/commands/contextHelp.ts
+++ b/src/ccs/commands/contextHelp.ts
@@ -161,8 +161,7 @@ async function applyResolvedTextExpression(
       const fallbackLine = document.lineAt(selection.active.line);
       rangeToReplace = fallbackLine.range;
     } else {
-      rangeToReplace =
-      contextInfo.replacementRange ?? new vscode.Range(selection.start, selection.end);
+      rangeToReplace = contextInfo.replacementRange ?? new vscode.Range(selection.start, selection.end);
     }
 
     await editor.edit((editBuilder) => {


### PR DESCRIPTION
This pull request introduces an adjustment to the context help logic to correctly handle cases where only a portion of a line is selected.

Previously, the behavior assumed that the entire line would be used when resolving context help. With this update, the feature now respects partial selections, allowing users to request context help for just a specific snippet within a line.