### PR TITLE
fix: remove invalid menu reference to editor.action.revealDefinition

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,10 @@
           "when": "false"
         },
         {
+          "command": "-editor.action.revealDefinition",
+          "when": "false"
+        },
+        {
           "command": "vscode-objectscript.compile",
           "when": "!(resourceScheme =~ /^isfs(-readonly)?$/) && editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive && !activeEditorIsDirty"
         },
@@ -910,6 +914,11 @@
         "command": "vscode-objectscript.ccs.jumpToTagOffsetCrossEntity.insertSelection",
         "title": "Insert Selection (Quick Pick)",
         "enablement": "inQuickOpen && vscode-objectscript.ccs.jumpToTagQuickPickActive"
+      },
+      {
+        "category": "ObjectScript (Internal)",
+        "command": "-editor.action.revealDefinition",
+        "title": "Remove built-in Go to Definition menu item"
       },
       {
         "category": "ObjectScript",


### PR DESCRIPTION
Fixes a Runtime Status warning caused by an invalid menu command reference to
`editor.action.revealDefinition`.

Fixes #77 
