### PR TITLE
Feat: Locate-triggers - add company filter support

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,10 @@
           "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
         },
         {
+          "command": "vscode-objectscript.ccs.locateTriggersByCompany",
+          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
+        },
+        {
           "command": "vscode-objectscript.subclass",
           "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
         },
@@ -893,6 +897,11 @@
         "category": "Consistem",
         "command": "vscode-objectscript.ccs.locateTriggers",
         "title": "Locate Triggers"
+      },
+      {
+        "category": "Consistem",
+        "command": "vscode-objectscript.ccs.locateTriggersByCompany",
+        "title": "Localizar Gatilhos por Empresa"
       },
       {
         "category": "Consistem",

--- a/src/ccs/AGENTS.md
+++ b/src/ccs/AGENTS.md
@@ -54,6 +54,9 @@ Base path: `GET/POST {baseURL}/api/sourcecontrol/vscode` (see `BASE_PATH` in `sr
 - `POST /namespaces/{NAMESPACE}/localizarGatilhos`
   - Used by: `vscode-objectscript.ccs.locateTriggers` (`src/ccs/commands/locateTriggers.ts`)
   - Behavior: locates triggers and supports opening returned locations.
+- `POST /namespaces/{NAMESPACE}/obterGatilhosPorEmpresa`
+  - Used by: `vscode-objectscript.ccs.locateTriggersByCompany` (`src/ccs/commands/locateTriggers.ts`)
+  - Behavior: returns available company accounts and trigger counts for a routine.
 
 ## Reliability & UX
 

--- a/src/ccs/index.ts
+++ b/src/ccs/index.ts
@@ -16,7 +16,7 @@ export {
 export { goToDefinitionLocalFirst } from "./commands/goToDefinitionLocalFirst";
 export { followDefinitionLink } from "./commands/followDefinitionLink";
 export { jumpToTagAndOffsetCrossEntity } from "./commands/jumpToTagOffsetCrossEntity";
-export { locateTriggers, openLocatedTriggerLocation } from "./commands/locateTriggers";
+export { locateTriggers, locateTriggersByCompany, openLocatedTriggerLocation } from "./commands/locateTriggers";
 export { PrioritizedDefinitionProvider } from "./providers/PrioritizedDefinitionProvider";
 export {
   DefinitionDocumentLinkProvider,

--- a/src/ccs/sourcecontrol/clients/locateTriggersClient.ts
+++ b/src/ccs/sourcecontrol/clients/locateTriggersClient.ts
@@ -10,6 +10,69 @@ import { ROUTES } from "../routes";
 export interface LocateTriggersPayload {
   routineName: string;
   selectedText?: string;
+  conta?: string;
+}
+
+export interface LocateTriggerCompaniesPayload {
+  routineName: string;
+  selectedText?: string;
+}
+
+export interface TriggerCompany {
+  conta: string;
+  descricaoConta: string;
+  quantidade: number;
+}
+
+function parseTriggerCompaniesResponse(data: unknown): TriggerCompany[] {
+  const toCompany = (item: unknown): TriggerCompany | undefined => {
+    if (typeof item !== "object" || item === null) {
+      return undefined;
+    }
+
+    const candidate = item as Record<string, unknown>;
+    const conta = typeof candidate.conta === "string" ? candidate.conta : undefined;
+    const descricaoConta = typeof candidate.descricaoConta === "string" ? candidate.descricaoConta : undefined;
+    const quantidadeRaw = candidate.quantidade;
+    const quantidade =
+      typeof quantidadeRaw === "number"
+        ? quantidadeRaw
+        : typeof quantidadeRaw === "string"
+          ? Number.parseInt(quantidadeRaw, 10)
+          : Number.NaN;
+
+    if (!conta || !descricaoConta || !Number.isFinite(quantidade)) {
+      return undefined;
+    }
+
+    return { conta, descricaoConta, quantidade };
+  };
+
+  const asArray = (value: unknown): TriggerCompany[] =>
+    Array.isArray(value)
+      ? value.map((item) => toCompany(item)).filter((item): item is TriggerCompany => item !== undefined)
+      : [];
+
+  const direct = asArray(data);
+
+  if (direct.length) {
+    return direct;
+  }
+
+  if (typeof data !== "object" || data === null) {
+    return [];
+  }
+
+  const wrapped = data as Record<string, unknown>;
+
+  return (
+    asArray(wrapped.listaConta) ||
+    asArray(wrapped.empresas) ||
+    asArray(wrapped.items) ||
+    asArray(wrapped.data) ||
+    asArray(wrapped.result) ||
+    []
+  );
 }
 
 export class LocateTriggersClient {
@@ -19,6 +82,45 @@ export class LocateTriggersClient {
     this.apiFactory = apiFactory;
   }
 
+  public async getCompanies(
+    document: vscode.TextDocument,
+    payload: LocateTriggerCompaniesPayload,
+    token?: vscode.CancellationToken
+  ): Promise<TriggerCompany[]> {
+    const api = this.resolveApi(document);
+
+    let sourceControlApi: SourceControlApi;
+    try {
+      sourceControlApi = this.apiFactory(api);
+    } catch (error) {
+      logDebug("Failed to create SourceControl API client for obter gatilhos por empresa", error);
+      throw error;
+    }
+
+    const { requestTimeout } = getCcsSettings();
+    const { signal, dispose } = createAbortSignal(token);
+
+    const requestConfig = {
+      timeout: requestTimeout,
+      signal,
+      validateStatus: (status: number) => status >= 200 && status < 300,
+    };
+
+    try {
+      const response = await sourceControlApi.post<TriggerCompany[]>(
+        ROUTES.getTriggerCompanies(api.ns),
+        payload,
+        requestConfig
+      );
+
+      return parseTriggerCompaniesResponse(response.data);
+    } catch (error) {
+      logDebug("Obter gatilhos por empresa request failed", error);
+      throw error;
+    } finally {
+      dispose();
+    }
+  }
   public async locate(
     document: vscode.TextDocument,
     payload: LocateTriggersPayload,

--- a/src/ccs/sourcecontrol/routes.ts
+++ b/src/ccs/sourcecontrol/routes.ts
@@ -7,6 +7,7 @@ export const ROUTES = {
   createItem: (namespace: string) => `/namespaces/${encodeURIComponent(namespace)}/createItem`,
   runUnitTests: (namespace: string) => `/namespaces/${encodeURIComponent(namespace)}/unitTests/runUnitTests`,
   locateTriggers: (namespace: string) => `/namespaces/${encodeURIComponent(namespace)}/localizarGatilhos`,
+  getTriggerCompanies: (namespace: string) => `/namespaces/${encodeURIComponent(namespace)}/obterGatilhosPorEmpresa`,
 } as const;
 
 export type RouteKey = keyof typeof ROUTES;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,6 +167,7 @@ import {
   resolveContextExpression,
   showGlobalDocumentation,
   locateTriggers,
+  locateTriggersByCompany,
   openLocatedTriggerLocation,
 } from "./ccs";
 
@@ -1419,6 +1420,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     vscode.commands.registerCommand("vscode-objectscript.ccs.locateTriggers", () => {
       sendCommandTelemetryEvent("locateTriggers");
       void locateTriggers();
+    }),
+    vscode.commands.registerCommand("vscode-objectscript.ccs.locateTriggersByCompany", () => {
+      sendCommandTelemetryEvent("locateTriggersByCompany");
+      void locateTriggersByCompany();
     }),
     vscode.commands.registerCommand("vscode-objectscript.ccs.locateTriggers.openLocation", (location) => {
       sendCommandTelemetryEvent("locateTriggers.openLocation");


### PR DESCRIPTION
# Implements company-level filtering in the Locate Triggers feature.

The command now allows selecting a specific company before searching triggers.
If no company is selected, the search runs across all companies.

Issue: #85 