### PR TITLE
Feat: implement converterArquivo and converterArquivoCustomizado endpoints with text/plain response 

### DIFF
--- a/package.json
+++ b/package.json
@@ -362,6 +362,14 @@
         {
           "command": "vscode-objectscript.connectFolderToServerNamespace",
           "when": "!vscode-objectscript.connectActive && vscode-objectscript.explorerRootCount == 0 && workspaceFolderCount != 0"
+        },
+        {
+          "command": "vscode-objectscript.ccs.convertCurrentItem",
+          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
+        },
+        {
+          "command": "vscode-objectscript.ccs.convertCurrentItemCustom",
+          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
         }
       ],
       "view/title": [
@@ -1305,6 +1313,16 @@
         "command": "vscode-objectscript.showAllClassMembers",
         "title": "Show All Class Members",
         "icon": "$(symbol-class)"
+      },
+      {
+        "category": "Consistem",
+        "command": "vscode-objectscript.ccs.convertCurrentItem",
+        "title": "Converter Item (Simples)"
+      },
+      {
+        "category": "Consistem",
+        "command": "vscode-objectscript.ccs.convertCurrentItemCustom",
+        "title": "Converter Item Customizado"
       }
     ],
     "keybindings": [
@@ -1369,6 +1387,22 @@
             "type": "string",
             "default": "",
             "when": "config.consistem.globalDocumentation.openInFile"
+          },
+          "consistem.converterItem.autoConvertOnSave": {
+            "description": "Converter Item ao Salvar",
+            "type": "boolean",
+            "default": true
+          },
+          "consistem.converterItem.autoConvertExcludePackages": {
+            "markdownDescription": "Excluir pacotes ao Salvar e Converter Item Automático (ex.: `cswutil70`). Essa opção depende de `consistem.converterItem.autoConvertOnSave` ativado.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": [
+              "cswutil70"
+            ],
+            "when": "config.consistem.converterItem.autoConvertOnSave"
           }
         }
       },

--- a/src/ccs/AGENTS.md
+++ b/src/ccs/AGENTS.md
@@ -57,6 +57,12 @@ Base path: `GET/POST {baseURL}/api/sourcecontrol/vscode` (see `BASE_PATH` in `sr
 - `POST /namespaces/{NAMESPACE}/obterGatilhosPorEmpresa`
   - Used by: `vscode-objectscript.ccs.locateTriggersByCompany` (`src/ccs/commands/locateTriggers.ts`)
   - Behavior: returns available company accounts and trigger counts for a routine.
+- `POST /namespaces/{NAMESPACE}/converterArquivo`
+  - Used by: `vscode-objectscript.ccs.convertCurrentItem` (`src/ccs/commands/converterItem.ts`)
+  - Behavior: runs default conversion for the active routine/file and returns plain text output.
+- `POST /namespaces/{NAMESPACE}/converterArquivoCustomizado`
+  - Used by: `vscode-objectscript.ccs.convertCurrentItemCustom` (`src/ccs/commands/converterItem.ts`)
+  - Behavior: runs conversion with user-selected options and returns plain text output.
 
 ## Reliability & UX
 

--- a/src/ccs/commands/converterItem.ts
+++ b/src/ccs/commands/converterItem.ts
@@ -1,0 +1,178 @@
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { waitForCompileToFinish } from "../../commands/compile";
+import { handleError, outputChannel } from "../../utils";
+import { getCcsSettings } from "../config/settings";
+import { logDebug } from "../core/logging";
+import { ConverterClient, ConverterCustomRequestBody } from "../sourcecontrol/clients/converterClient";
+
+const sharedClient = new ConverterClient();
+
+interface NumericOption<T extends number> extends vscode.QuickPickItem {
+  value: T;
+}
+
+const tipoConversaoOptions: NumericOption<0 | 1 | 2>[] = [
+  { label: "Completa", description: "0", value: 0 },
+  { label: "Básica", description: "1", value: 1 },
+  { label: "Somente Flags", description: "2", value: 2 },
+];
+
+const persistenciaOptions: NumericOption<0 | 1 | 2>[] = [
+  { label: "Não", description: "0", value: 0 },
+  { label: "Globais Conf.", description: "1", value: 1 },
+  { label: "Todas as Globais", description: "2", value: 2 },
+];
+
+const eliminarCsmvOptions: NumericOption<0 | 1>[] = [
+  { label: "Sim", description: "0", value: 0 },
+  { label: "Não", description: "1", value: 1 },
+];
+
+const flagsOptions: vscode.QuickPickItem[] = [{ label: "agrupSetPiece" }, { label: "objDynamic" }];
+
+export async function convertCurrentItem(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+
+  if (!editor) {
+    void vscode.window.showErrorMessage("Nenhum arquivo ativo para conversão.");
+    return;
+  }
+
+  await convertDocumentItem(editor.document, "Falha ao converter item.");
+}
+
+export async function convertCurrentItemCustom(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+
+  if (!editor) {
+    void vscode.window.showErrorMessage("Nenhum arquivo ativo para conversão.");
+    return;
+  }
+
+  const item = getItemName(editor.document);
+
+  try {
+    const tipoConversao = await pickOption("Tipo de conversão", tipoConversaoOptions);
+    if (tipoConversao === undefined) return;
+
+    const flgPersistencia = await pickOption("Persistência", persistenciaOptions);
+    if (flgPersistencia === undefined) return;
+
+    const flgEliminarCSMV = await pickOption("Eliminar %CSMV", eliminarCsmvOptions);
+    if (flgEliminarCSMV === undefined) return;
+
+    const selectedFlags = await vscode.window.showQuickPick(flagsOptions, {
+      title: "Flags de conversão",
+      placeHolder: "Selecione as flags de conversão",
+      canPickMany: true,
+      ignoreFocusOut: true,
+    });
+
+    if (selectedFlags === undefined) return;
+
+    const strParamPersist = await vscode.window.showInputBox({
+      title: "Complemento de persistência",
+      prompt: "Informe strParamPersist (opcional)",
+      placeHolder: "Ex: -log",
+      ignoreFocusOut: true,
+    });
+
+    if (strParamPersist === undefined) return;
+
+    const payload: ConverterCustomRequestBody = {
+      item,
+      tipoConversao,
+      flgPersistencia,
+      flgEliminarCSMV,
+      strFlagsConv: selectedFlags.map((flag) => flag.label).join(","),
+      strParamPersist,
+    };
+
+    const responseText = await sharedClient.convertCustom(editor.document, payload);
+
+    renderConversionOutput(responseText);
+  } catch (error) {
+    handleError(error, "Falha ao converter item customizado.");
+  }
+}
+
+export async function convertCurrentItemOnSave(document: vscode.TextDocument): Promise<void> {
+  const settings = getCcsSettings();
+
+  if (
+    !settings.autoConvertOnSave ||
+    !isMacDocument(document) ||
+    isInExcludedPackage(document, settings.autoConvertExcludePackages)
+  ) {
+    return;
+  }
+
+  await waitForCompileBeforeAutoConvert(document);
+  await convertDocumentItem(document, "Falha ao converter item automaticamente ao salvar.", true);
+}
+
+async function waitForCompileBeforeAutoConvert(document: vscode.TextDocument): Promise<void> {
+  try {
+    await waitForCompileToFinish(document);
+  } catch (error) {
+    logDebug("Falha ao aguardar compilação antes da conversão automática", error);
+  }
+}
+
+async function convertDocumentItem(
+  document: vscode.TextDocument,
+  errorMessage: string,
+  silentError = false
+): Promise<void> {
+  const item = getItemName(document);
+
+  try {
+    const responseText = await sharedClient.convertDefault(document, item);
+    renderConversionOutput(responseText);
+  } catch (error) {
+    if (silentError) {
+      logDebug("Falha na conversão automática ao salvar", error);
+      return;
+    }
+
+    handleError(error, errorMessage);
+  }
+}
+
+function isMacDocument(document: vscode.TextDocument): boolean {
+  return path.extname(document.fileName).toLowerCase() === ".mac";
+}
+
+function isInExcludedPackage(document: vscode.TextDocument, excludedPackages: string[]): boolean {
+  const normalizedExcluded = new Set(excludedPackages.map((pkg) => pkg.toLowerCase()));
+  const pathParts = document.fileName
+    .split(/[/\\]+/)
+    .map((part) => part.trim().toLowerCase())
+    .filter((part) => part.length > 0);
+
+  return pathParts.some((part) => normalizedExcluded.has(part));
+}
+
+function renderConversionOutput(responseText: string): void {
+  responseText
+    .split(/\r?\n/)
+    .filter((line) => line.length > 0)
+    .forEach((line) => outputChannel.appendLine(line));
+
+  outputChannel.show(true);
+}
+
+async function pickOption<T extends number>(title: string, options: NumericOption<T>[]): Promise<T | undefined> {
+  const selected = await vscode.window.showQuickPick(options, {
+    title,
+    ignoreFocusOut: true,
+  });
+
+  return selected?.value;
+}
+
+function getItemName(document: vscode.TextDocument): string {
+  return path.basename(document.fileName);
+}

--- a/src/ccs/config/schema.md
+++ b/src/ccs/config/schema.md
@@ -1,13 +1,17 @@
 # Configuração do módulo CCS
 
-As opções abaixo ficam no escopo `objectscript.ccs` e controlam as integrações específicas
-para o fork da Consistem.
+As opções abaixo controlam as integrações específicas para o fork da Consistem.
 
-| Chave            | Tipo                      | Padrão      | Descrição                                                                                                       |
-| ---------------- | ------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------- |
-| `endpoint`       | `string`                  | `undefined` | URL base alternativa para a API. Se não definida, a URL é derivada da conexão ativa do Atelier.                 |
-| `requestTimeout` | `number`                  | `5000`       | Tempo limite (ms) aplicado às chamadas HTTP do módulo. Valores menores ou inválidos são normalizados para zero. |
-| `debugLogging`   | `boolean`                 | `false`     | Quando verdadeiro, registra mensagens detalhadas no `ObjectScript` Output Channel.                              |
-| `flags`          | `Record<string, boolean>` | `{}`        | Feature flags opcionais que podem ser lidas pelas features do módulo.                                           |
+| Chave                                     | Tipo                      | Padrão         | Descrição                                                                                                         |
+| ----------------------------------------- | ------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `objectscript.ccs.endpoint`               | `string`                  | `undefined`    | URL base alternativa para a API. Se não definida, a URL é derivada da conexão ativa do Atelier.                 |
+| `objectscript.ccs.requestTimeout`         | `number`                  | `5000`         | Tempo limite (ms) aplicado às chamadas HTTP do módulo. Valores menores ou inválidos são normalizados para zero. |
+| `objectscript.ccs.debugLogging`           | `boolean`                 | `false`        | Quando verdadeiro, registra mensagens detalhadas no `ObjectScript` Output Channel.                               |
+| `objectscript.ccs.flags`                  | `Record<string, boolean>` | `{}`           | Feature flags opcionais que podem ser lidas pelas features do módulo.                                            |
+| `consistem.converterItem.autoConvertOnSave`          | `boolean`                 | `true`         | Quando verdadeiro, executa a conversão simples ao salvar arquivos `.mac`.                                        |
+| `consistem.converterItem.autoConvertExcludePackages` | `string[]`                | `["cswutil70"]` | Lista de pacotes/pastas excluídos da conversão automática ao salvar.                                              |
+
+> Compatibilidade: as chaves antigas `objectscript.ccs.autoConvertOnSave` e
+> `objectscript.ccs.autoConvertExcludePackages` ainda são lidas como fallback.
 
 Essas configurações não exigem reload da janela; toda leitura é feita sob demanda.

--- a/src/ccs/config/settings.ts
+++ b/src/ccs/config/settings.ts
@@ -5,10 +5,14 @@ export interface CcsSettings {
   requestTimeout: number;
   debugLogging: boolean;
   flags: Record<string, boolean>;
+  autoConvertOnSave: boolean;
+  autoConvertExcludePackages: string[];
 }
 
 const CCS_CONFIGURATION_SECTION = "objectscript.ccs";
+const CONSISTEM_CONFIGURATION_SECTION = "consistem";
 const DEFAULT_TIMEOUT = 5000;
+const DEFAULT_AUTO_CONVERT_EXCLUDE_PACKAGES = ["cswutil70"];
 
 export function getCcsSettings(): CcsSettings {
   const configuration = vscode.workspace.getConfiguration(CCS_CONFIGURATION_SECTION);
@@ -16,12 +20,19 @@ export function getCcsSettings(): CcsSettings {
   const requestTimeout = coerceTimeout(configuration.get<number | undefined>("requestTimeout"));
   const debugLogging = Boolean(configuration.get<boolean | undefined>("debugLogging"));
   const flags = configuration.get<Record<string, boolean>>("flags") ?? {};
+  const consistemConfiguration = vscode.workspace.getConfiguration(CONSISTEM_CONFIGURATION_SECTION);
+  const autoConvertOnSave = getAutoConvertOnSaveSetting(consistemConfiguration);
+  const autoConvertExcludePackages = sanitizeExcludePackages(
+    getAutoConvertExcludePackagesSetting(consistemConfiguration)
+  );
 
   return {
     endpoint,
     requestTimeout,
     debugLogging,
     flags,
+    autoConvertOnSave,
+    autoConvertExcludePackages,
   };
 }
 
@@ -48,4 +59,36 @@ function coerceTimeout(timeout: number | undefined): number {
   }
 
   return Math.max(0, Math.floor(timeout));
+}
+
+function sanitizeExcludePackages(packages: string[] | undefined): string[] {
+  if (!Array.isArray(packages)) {
+    return DEFAULT_AUTO_CONVERT_EXCLUDE_PACKAGES;
+  }
+
+  return packages
+    .map((pkg) => (typeof pkg === "string" ? pkg.trim().toLowerCase() : ""))
+    .filter((pkg) => pkg.length > 0);
+}
+
+function getAutoConvertOnSaveSetting(configuration: vscode.WorkspaceConfiguration): boolean {
+  const consistemValue = configuration.get<boolean | undefined>("converterItem.autoConvertOnSave");
+  if (typeof consistemValue === "boolean") {
+    return consistemValue;
+  }
+
+  // Backward compatibility for previous key path
+  return vscode.workspace.getConfiguration(CCS_CONFIGURATION_SECTION).get<boolean>("autoConvertOnSave", true);
+}
+
+function getAutoConvertExcludePackagesSetting(configuration: vscode.WorkspaceConfiguration): string[] | undefined {
+  const consistemValue = configuration.get<string[] | undefined>("converterItem.autoConvertExcludePackages");
+  if (Array.isArray(consistemValue)) {
+    return consistemValue;
+  }
+
+  // Backward compatibility for previous key path
+  return vscode.workspace
+    .getConfiguration(CCS_CONFIGURATION_SECTION)
+    .get<string[] | undefined>("autoConvertExcludePackages");
 }

--- a/src/ccs/index.ts
+++ b/src/ccs/index.ts
@@ -29,3 +29,5 @@ export {
   followSourceAnalysisLinkCommand,
 } from "./providers/SourceAnalysisLinkProvider";
 export { createItem } from "./commands/createItem";
+
+export { convertCurrentItem, convertCurrentItemCustom, convertCurrentItemOnSave } from "./commands/converterItem";

--- a/src/ccs/sourcecontrol/clients/converterClient.ts
+++ b/src/ccs/sourcecontrol/clients/converterClient.ts
@@ -1,0 +1,183 @@
+import * as vscode from "vscode";
+
+import { AtelierAPI } from "../../../api";
+import { getCcsSettings } from "../../config/settings";
+import { createAbortSignal } from "../../core/http";
+import { logDebug } from "../../core/logging";
+import { SourceControlApi } from "../client";
+import { ROUTES } from "../routes";
+
+const ALLOWED_FLAGS = new Set(["agrupSetPiece", "objDynamic"]);
+
+export interface ConverterRequestBody {
+  item: string;
+}
+
+export interface ConverterCustomRequestBody extends ConverterRequestBody {
+  tipoConversao: 0 | 1 | 2;
+  flgPersistencia: 0 | 1 | 2;
+  flgEliminarCSMV: 0 | 1;
+  strFlagsConv?: string;
+  strParamPersist?: string;
+}
+
+export interface ConverterCoreParams {
+  tipoConversao?: number;
+  flgPersistencia?: number;
+  flgEliminarCSMV?: number;
+  strFlagsConv?: string;
+  strParamPersist?: string;
+}
+
+export class ConverterClient {
+  private readonly apiFactory: (api: AtelierAPI) => SourceControlApi;
+
+  public constructor(apiFactory: (api: AtelierAPI) => SourceControlApi = SourceControlApi.fromAtelierApi) {
+    this.apiFactory = apiFactory;
+  }
+
+  public async convertDefault(
+    document: vscode.TextDocument,
+    item: string,
+    token?: vscode.CancellationToken
+  ): Promise<string> {
+    this.validateItem(item);
+    return this.converterCore(document, item, {}, token);
+  }
+
+  public async convertCustom(
+    document: vscode.TextDocument,
+    params: ConverterCustomRequestBody,
+    token?: vscode.CancellationToken
+  ): Promise<string> {
+    this.validateItem(params.item);
+    this.validateTipoConversao(params.tipoConversao);
+    this.validateFlgPersistencia(params.flgPersistencia);
+    this.validateFlgEliminarCSMV(params.flgEliminarCSMV);
+
+    return this.converterCore(document, params.item, params, token);
+  }
+
+  private async converterCore(
+    document: vscode.TextDocument,
+    item: string,
+    params: ConverterCoreParams,
+    token?: vscode.CancellationToken
+  ): Promise<string> {
+    const api = this.resolveApi(document);
+
+    let sourceControlApi: SourceControlApi;
+    try {
+      sourceControlApi = this.apiFactory(api);
+    } catch (error) {
+      logDebug("Failed to create SourceControl API client for conversão", error);
+      throw error;
+    }
+
+    const body: ConverterRequestBody | ConverterCustomRequestBody = {
+      item,
+      ...(this.hasCustomParams(params)
+        ? {
+            tipoConversao: params.tipoConversao ?? 0,
+            flgPersistencia: params.flgPersistencia ?? 0,
+            flgEliminarCSMV: params.flgEliminarCSMV ?? 0,
+            strFlagsConv: this.normalizeFlags(params.strFlagsConv),
+            strParamPersist: params.strParamPersist?.trim() ?? "",
+          }
+        : {}),
+    };
+
+    const route = this.hasCustomParams(params)
+      ? ROUTES.converterArquivoCustomizado(api.ns)
+      : ROUTES.converterArquivo(api.ns);
+
+    const { requestTimeout } = getCcsSettings();
+    const { signal, dispose } = createAbortSignal(token);
+
+    try {
+      const response = await sourceControlApi.post<string>(route, body, {
+        timeout: requestTimeout,
+        signal,
+        responseType: "text",
+        transformResponse: (data) => data,
+        validateStatus: (status) => status >= 200 && status < 300,
+      });
+
+      return typeof response.data === "string" ? response.data : "";
+    } catch (error) {
+      logDebug("Conversão de arquivo request failed", error);
+      throw error;
+    } finally {
+      dispose();
+    }
+  }
+
+  private resolveApi(document: vscode.TextDocument): AtelierAPI {
+    let api = new AtelierAPI(document.uri);
+
+    if (!api.active || !api.ns) {
+      const fallbackApi = new AtelierAPI();
+
+      if (fallbackApi.active && fallbackApi.ns) {
+        api = fallbackApi;
+      } else {
+        throw new Error("No active namespace for conversão de arquivo.");
+      }
+    }
+
+    return api;
+  }
+
+  private hasCustomParams(params: ConverterCoreParams): boolean {
+    return (
+      typeof params.tipoConversao !== "undefined" ||
+      typeof params.flgPersistencia !== "undefined" ||
+      typeof params.flgEliminarCSMV !== "undefined" ||
+      typeof params.strFlagsConv !== "undefined" ||
+      typeof params.strParamPersist !== "undefined"
+    );
+  }
+
+  private normalizeFlags(flags?: string): string {
+    if (!flags?.trim()) {
+      return "";
+    }
+
+    const normalized = flags
+      .split(",")
+      .map((flag) => flag.trim())
+      .filter((flag) => flag.length > 0);
+
+    normalized.forEach((flag) => {
+      if (!ALLOWED_FLAGS.has(flag)) {
+        throw new Error(`Flag inválida em strFlagsConv: ${flag}.`);
+      }
+    });
+
+    return normalized.join(",");
+  }
+
+  private validateItem(item: string): void {
+    if (!item?.trim()) {
+      throw new Error("O campo 'item' é obrigatório.");
+    }
+  }
+
+  private validateTipoConversao(tipoConversao: number): void {
+    if (![0, 1, 2].includes(tipoConversao)) {
+      throw new Error("tipoConversao deve ser 0, 1 ou 2.");
+    }
+  }
+
+  private validateFlgPersistencia(flgPersistencia: number): void {
+    if (![0, 1, 2].includes(flgPersistencia)) {
+      throw new Error("flgPersistencia deve ser 0, 1 ou 2.");
+    }
+  }
+
+  private validateFlgEliminarCSMV(flgEliminarCSMV: number): void {
+    if (![0, 1].includes(flgEliminarCSMV)) {
+      throw new Error("flgEliminarCSMV deve ser 0 ou 1.");
+    }
+  }
+}

--- a/src/ccs/sourcecontrol/routes.ts
+++ b/src/ccs/sourcecontrol/routes.ts
@@ -8,6 +8,9 @@ export const ROUTES = {
   runUnitTests: (namespace: string) => `/namespaces/${encodeURIComponent(namespace)}/unitTests/runUnitTests`,
   locateTriggers: (namespace: string) => `/namespaces/${encodeURIComponent(namespace)}/localizarGatilhos`,
   getTriggerCompanies: (namespace: string) => `/namespaces/${encodeURIComponent(namespace)}/obterGatilhosPorEmpresa`,
+  converterArquivo: (namespace: string) => `/namespaces/${encodeURIComponent(namespace)}/converterArquivo`,
+  converterArquivoCustomizado: (namespace: string) =>
+    `/namespaces/${encodeURIComponent(namespace)}/converterArquivoCustomizado`,
 } as const;
 
 export type RouteKey = keyof typeof ROUTES;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -169,6 +169,9 @@ import {
   locateTriggers,
   locateTriggersByCompany,
   openLocatedTriggerLocation,
+  convertCurrentItem,
+  convertCurrentItemCustom,
+  convertCurrentItemOnSave,
 } from "./ccs";
 
 const packageJson = vscode.extensions.getExtension(extensionId).packageJSON;
@@ -1429,6 +1432,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       sendCommandTelemetryEvent("locateTriggers.openLocation");
       void openLocatedTriggerLocation(location);
     }),
+    vscode.commands.registerCommand("vscode-objectscript.ccs.convertCurrentItem", () => {
+      sendCommandTelemetryEvent("convertCurrentItem");
+      void convertCurrentItem();
+    }),
+    vscode.commands.registerCommand("vscode-objectscript.ccs.convertCurrentItemCustom", () => {
+      sendCommandTelemetryEvent("convertCurrentItemCustom");
+      void convertCurrentItemCustom();
+    }),
     vscode.commands.registerCommand("vscode-objectscript.serverCommands.sourceControl", (uri?: vscode.Uri) => {
       sendCommandTelemetryEvent("serverCommands.sourceControl");
       mainSourceControlMenu(uri);
@@ -2016,6 +2027,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       if (uri instanceof vscode.Uri) showAllClassMembers(uri);
     }),
     vscode.workspace.onDidSaveTextDocument((d) => {
+      void convertCurrentItemOnSave(d);
+
       // If the document just saved is a server-side document that needs to be updated in the UI,
       // then force VS Code to update the document's contents. This is needed if the document has
       // been changed during a save, for example by adding or changing the Storage definition.


### PR DESCRIPTION
- Add POST /namespaces/:nsReq/converterArquivo
- Add POST /namespaces/:nsReq/converterArquivoCustomizado
- Return plain text output (text/plain)
- Centralize logic in converterCore
- Validate body fields and allowed flags
- Prepare VSCode to consume response via response.text()"

Issue: #63 