### PR TITLE
Task: Translate CCS interface to pt-BR

### DIFF
--- a/package.json
+++ b/package.json
@@ -884,27 +884,27 @@
       {
         "category": "Consistem",
         "command": "vscode-objectscript.ccs.resolveContextExpression",
-        "title": "Resolve Context Expression"
+        "title": "Ajuda de Contexto"
       },
       {
         "category": "Consistem",
         "command": "vscode-objectscript.ccs.goToDefinition",
-        "title": "Go to Definition"
+        "title": "Ir para Definição"
       },
       {
         "category": "Consistem",
         "command": "vscode-objectscript.ccs.followDefinitionLink",
-        "title": "Follow Definition Link"
+        "title": "Seguir Link de Definição"
       },
       {
         "category": "Consistem",
         "command": "vscode-objectscript.ccs.followSourceAnalysisLink",
-        "title": "Follow Source Analysis Link"
+        "title": "Seguir Link de Análise de Código-Fonte"
       },
       {
         "category": "Consistem",
         "command": "vscode-objectscript.ccs.locateTriggers",
-        "title": "Locate Triggers"
+        "title": "Localizar Gatilhos"
       },
       {
         "category": "Consistem",
@@ -914,22 +914,22 @@
       {
         "category": "Consistem",
         "command": "vscode-objectscript.ccs.locateTriggers.openLocation",
-        "title": "Open Located Trigger"
+        "title": "Abrir Gatilho Localizado"
       },
       {
         "category": "Consistem",
         "command": "vscode-objectscript.ccs.createItem",
-        "title": "Create Item"
+        "title": "Criar Item"
       },
       {
         "category": "Consistem",
         "command": "vscode-objectscript.ccs.jumpToTagOffsetCrossEntity",
-        "title": "Go to Definition (+Offset ^Item)"
+        "title": "Ir para Definição (+linha ^Item)"
       },
       {
         "category": "Consistem",
         "command": "vscode-objectscript.ccs.jumpToTagOffsetCrossEntity.insertSelection",
-        "title": "Insert Selection (Quick Pick)",
+        "title": "Inserir Seleção (Quick Pick)",
         "enablement": "inQuickOpen && vscode-objectscript.ccs.jumpToTagQuickPickActive"
       },
       {
@@ -1045,7 +1045,7 @@
         "category": "ObjectScript",
         "command": "vscode-objectscript.ccs.getGlobalDocumentation",
         "enablement": "vscode-objectscript.connectActive",
-        "title": "Show Global Documentation"
+        "title": "Documentação Global"
       },
       {
         "category": "ObjectScript",
@@ -1317,7 +1317,7 @@
       {
         "category": "Consistem",
         "command": "vscode-objectscript.ccs.convertCurrentItem",
-        "title": "Converter Item (Simples)"
+        "title": "Converter Item"
       },
       {
         "category": "Consistem",
@@ -1378,12 +1378,12 @@
         "type": "object",
         "properties": {
           "consistem.globalDocumentation.openInFile": {
-            "description": "Open global documentation in a file instead of the Output view.",
+            "description": "Abrir a documentação global em um arquivo em vez da visualização de Saída.",
             "type": "boolean",
             "default": true
           },
           "consistem.globalDocumentation.filePath": {
-            "markdownDescription": "Path to the file where global documentation is written. Relative paths are resolved against the system temporary directory (e.g. %TEMP% on Windows). If empty, defaults to `%TEMP%\\globalDocumentation.txt`.",
+            "markdownDescription": "Caminho do arquivo onde a documentação global será gravada. Caminhos relativos são resolvidos em relação ao diretório temporário do sistema (ex.: %TEMP% no Windows). Se estiver vazio, o padrão será `%TEMP%\\globalDocumentation.txt`.",
             "type": "string",
             "default": "",
             "when": "config.consistem.globalDocumentation.openInFile"

--- a/src/ccs/commands/contextHelp.ts
+++ b/src/ccs/commands/contextHelp.ts
@@ -21,7 +21,7 @@ export async function resolveContextExpression(): Promise<void> {
   const contextExpression = contextInfo.text;
 
   if (!contextExpression.trim()) {
-    void vscode.window.showErrorMessage("Context expression is empty.");
+    void vscode.window.showErrorMessage("A expressão da ajuda de contexto está vazia.");
     return;
   }
 
@@ -69,10 +69,10 @@ export async function resolveContextExpression(): Promise<void> {
     const errorMessage =
       typeof data === "object" && data && "message" in data && typeof data.message === "string"
         ? data.message
-        : "Failed to resolve context expression.";
+        : "Falha ao resolver a ajuda de contexto.";
     void vscode.window.showErrorMessage(errorMessage);
   } catch (error) {
-    handleError(error, "Failed to resolve context expression.");
+    handleError(error, "Falha ao resolver a ajuda de contexto.");
   }
 }
 
@@ -173,7 +173,7 @@ async function applyResolvedTextExpression(
     try {
       await showGifInWebview(gifUri);
     } catch (error) {
-      handleError(error, "Failed to open GIF from context expression.");
+      handleError(error, "Falha ao abrir o GIF da ajuda de contexto.");
     }
   }
 }
@@ -339,7 +339,7 @@ function normalizeGlobalDocumentationContent(content: GlobalDocumentationRespons
     try {
       return JSON.stringify(content, null, 2);
     } catch (error) {
-      handleError(error, "Failed to parse global documentation content.");
+      handleError(error, "Falha ao processar o conteúdo da documentação global.");
     }
   }
 
@@ -435,7 +435,7 @@ function getGifWebviewHtml(webview: vscode.Webview, gifUri: vscode.Uri, title: s
   const cspSource = escapeHtml(webview.cspSource);
 
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource} data:;" />

--- a/src/ccs/providers/DefinitionDocumentLinkProvider.ts
+++ b/src/ccs/providers/DefinitionDocumentLinkProvider.ts
@@ -54,7 +54,7 @@ export class DefinitionDocumentLinkProvider implements vscode.DocumentLinkProvid
         `command:${followDefinitionLinkCommand}?${encodeURIComponent(JSON.stringify(args))}`
       );
       const link = new vscode.DocumentLink(match.range, commandUri);
-      link.tooltip = vscode.l10n.t("Go to Definition");
+      link.tooltip = vscode.l10n.t("Ir para definição");
       return link;
     });
   }

--- a/src/ccs/providers/SourceAnalysisLinkProvider.ts
+++ b/src/ccs/providers/SourceAnalysisLinkProvider.ts
@@ -84,7 +84,7 @@ export class SourceAnalysisLinkProvider implements vscode.DocumentLinkProvider {
     );
 
     const link = new vscode.DocumentLink(range, commandUri);
-    link.tooltip = vscode.l10n.t("Open Source Analysis location");
+    link.tooltip = vscode.l10n.t("Abrir localização da análise de fonte");
     return link;
   }
 }

--- a/src/ccs/sourcecontrol/client.ts
+++ b/src/ccs/sourcecontrol/client.ts
@@ -17,7 +17,9 @@ export class SourceControlApi {
     const { host, port, username, password, https: useHttps, pathPrefix } = api.config;
 
     if (!host || !port) {
-      throw new Error("No active InterSystems server connection for this file.");
+      throw new Error(
+        "Nenhuma conexão ativa com servidor InterSystems foi encontrada para este arquivo. Verifique a conexão e o namespace selecionados."
+      );
     }
 
     const normalizedPrefix = pathPrefix ? (pathPrefix.startsWith("/") ? pathPrefix : `/${pathPrefix}`) : "";

--- a/src/ccs/sourcecontrol/clients/converterClient.ts
+++ b/src/ccs/sourcecontrol/clients/converterClient.ts
@@ -121,7 +121,9 @@ export class ConverterClient {
       if (fallbackApi.active && fallbackApi.ns) {
         api = fallbackApi;
       } else {
-        throw new Error("No active namespace for conversão de arquivo.");
+        throw new Error(
+          "Nenhum namespace ativo foi encontrado para conversão de arquivo. Verifique a conexão ativa e tente novamente."
+        );
       }
     }
 

--- a/src/ccs/sourcecontrol/clients/locateTriggersClient.ts
+++ b/src/ccs/sourcecontrol/clients/locateTriggersClient.ts
@@ -166,7 +166,9 @@ export class LocateTriggersClient {
       if (fallbackApi.active && fallbackApi.ns) {
         api = fallbackApi;
       } else {
-        throw new Error("No active namespace for localizar gatilhos.");
+        throw new Error(
+          "Nenhum namespace ativo foi encontrado para localizar gatilhos. Verifique a conexão ativa e tente novamente."
+        );
       }
     }
 


### PR DESCRIPTION
## Problem
There was text visible to the user in English in the CCS flow (commands, messages, tooltips, and settings).

## Approach
- Translation of CCS command titles in package.json
- Translation of error/warning/info messages, placeholders, progress, and output text
- Translation of link tooltips/document links
- Adjustment of messages propagated from clients to pt-BR
- Without altering command IDs or internal technical identifiers

**Issue:** #84 