### PR TITLE
Adds command to analyze item version in Consistem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-objectscript",
-  "version": "3.6.0-SNAPSHOT",
+  "version": "3.6.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-objectscript",
-      "version": "3.6.0-SNAPSHOT",
+      "version": "3.6.1-SNAPSHOT",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -358,6 +358,10 @@
         {
           "command": "vscode-objectscript.ccs.convertCurrentItemCustom",
           "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
+        },
+        {
+          "command": "vscode-objectscript.ccs.analizarVersaoItem",
+          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
         }
       ],
       "view/title": [
@@ -1269,6 +1273,11 @@
         "category": "Consistem",
         "command": "vscode-objectscript.ccs.convertCurrentItemCustom",
         "title": "Converter Item Customizado"
+      },
+      {
+        "category": "Consistem",
+        "command": "vscode-objectscript.ccs.analizarVersaoItem",
+        "title": "Versões do Item - Analizar"
       }
     ],
     "keybindings": [

--- a/src/ccs/commands/analizarVersaoItem.ts
+++ b/src/ccs/commands/analizarVersaoItem.ts
@@ -1,0 +1,78 @@
+import * as path from "path";
+import * as vscode from "vscode";
+
+import { AtelierAPI } from "../../api";
+import { handleError, outputChannel } from "../../utils";
+import { AnalizarVersaoItemClient } from "../sourcecontrol/clients/analizarVersaoItemClient";
+
+const sharedClient = new AnalizarVersaoItemClient();
+
+export async function analizarVersaoItem(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+
+  if (!editor) {
+    void vscode.window.showErrorMessage("Nenhum arquivo ativo para analizar versão do item.");
+    return;
+  }
+
+  const item = path.basename(editor.document.fileName);
+
+  if (!item) {
+    void vscode.window.showErrorMessage("Nome do item não disponível para analizar versão.");
+    return;
+  }
+
+  const api = resolveApi(editor.document);
+
+  if (!api) {
+    return;
+  }
+
+  const { username, password } = api.config;
+
+  if (typeof username !== "string" || typeof password !== "string") {
+    void vscode.window.showErrorMessage("Credenciais não disponíveis para analizar versão do item.");
+    return;
+  }
+
+  try {
+    const responseText = await sharedClient.analisar(editor.document, { item, username, password });
+
+    if (!responseText || !responseText.trim()) {
+      void vscode.window.showInformationMessage("Analizar Versão do Item não retornou nenhum conteúdo.");
+      return;
+    }
+
+    renderToOutput(responseText);
+  } catch (error) {
+    handleError(error, "Falha ao analizar versão do item.");
+  }
+}
+
+function resolveApi(document: vscode.TextDocument): AtelierAPI | undefined {
+  let api = new AtelierAPI(document.uri);
+
+  if (!api.active || !api.ns) {
+    const fallbackApi = new AtelierAPI();
+
+    if (fallbackApi.active && fallbackApi.ns) {
+      api = fallbackApi;
+    } else {
+      void vscode.window.showErrorMessage(
+        "Nenhum namespace ativo foi encontrado. Verifique a conexão ativa e tente novamente."
+      );
+      return undefined;
+    }
+  }
+
+  return api;
+}
+
+function renderToOutput(responseText: string): void {
+  responseText
+    .split(/\r?\n/)
+    .filter((line) => line.length > 0)
+    .forEach((line) => outputChannel.appendLine(line));
+
+  outputChannel.show(true);
+}

--- a/src/ccs/index.ts
+++ b/src/ccs/index.ts
@@ -31,3 +31,4 @@ export {
 export { createItem } from "./commands/createItem";
 
 export { convertCurrentItem, convertCurrentItemCustom, convertCurrentItemOnSave } from "./commands/converterItem";
+export { analizarVersaoItem } from "./commands/analizarVersaoItem";

--- a/src/ccs/sourcecontrol/clients/analizarVersaoItemClient.ts
+++ b/src/ccs/sourcecontrol/clients/analizarVersaoItemClient.ts
@@ -1,0 +1,76 @@
+import * as vscode from "vscode";
+
+import { AtelierAPI } from "../../../api";
+import { getCcsSettings } from "../../config/settings";
+import { createAbortSignal } from "../../core/http";
+import { logDebug } from "../../core/logging";
+import { SourceControlApi } from "../client";
+import { ROUTES } from "../routes";
+
+export interface AnalizarVersaoItemPayload {
+  item: string;
+  username: string;
+  password: string;
+}
+
+export class AnalizarVersaoItemClient {
+  private readonly apiFactory: (api: AtelierAPI) => SourceControlApi;
+
+  public constructor(apiFactory: (api: AtelierAPI) => SourceControlApi = SourceControlApi.fromAtelierApi) {
+    this.apiFactory = apiFactory;
+  }
+
+  public async analisar(
+    document: vscode.TextDocument,
+    payload: AnalizarVersaoItemPayload,
+    token?: vscode.CancellationToken
+  ): Promise<string> {
+    const api = this.resolveApi(document);
+
+    let sourceControlApi: SourceControlApi;
+    try {
+      sourceControlApi = this.apiFactory(api);
+    } catch (error) {
+      logDebug("Failed to create SourceControl API client for analizar versão do item", error);
+      throw error;
+    }
+
+    const { requestTimeout } = getCcsSettings();
+    const { signal, dispose } = createAbortSignal(token);
+
+    try {
+      const response = await sourceControlApi.post<string>(ROUTES.analizarVersaoItem(api.ns), payload, {
+        timeout: requestTimeout,
+        signal,
+        responseType: "text",
+        transformResponse: (data) => data,
+        validateStatus: (status) => status >= 200 && status < 300,
+      });
+
+      return typeof response.data === "string" ? response.data : "";
+    } catch (error) {
+      logDebug("Analizar versão do item request failed", error);
+      throw error;
+    } finally {
+      dispose();
+    }
+  }
+
+  private resolveApi(document: vscode.TextDocument): AtelierAPI {
+    let api = new AtelierAPI(document.uri);
+
+    if (!api.active || !api.ns) {
+      const fallbackApi = new AtelierAPI();
+
+      if (fallbackApi.active && fallbackApi.ns) {
+        api = fallbackApi;
+      } else {
+        throw new Error(
+          "Nenhum namespace ativo foi encontrado para analizar versão do item. Verifique a conexão ativa e tente novamente."
+        );
+      }
+    }
+
+    return api;
+  }
+}

--- a/src/ccs/sourcecontrol/routes.ts
+++ b/src/ccs/sourcecontrol/routes.ts
@@ -11,6 +11,7 @@ export const ROUTES = {
   converterArquivo: (namespace: string) => `/namespaces/${encodeURIComponent(namespace)}/converterArquivo`,
   converterArquivoCustomizado: (namespace: string) =>
     `/namespaces/${encodeURIComponent(namespace)}/converterArquivoCustomizado`,
+  analizarVersaoItem: (namespace: string) => `/namespaces/${encodeURIComponent(namespace)}/analizarVersaoItem`,
 } as const;
 
 export type RouteKey = keyof typeof ROUTES;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -171,6 +171,7 @@ import {
   convertCurrentItem,
   convertCurrentItemCustom,
   convertCurrentItemOnSave,
+  analizarVersaoItem,
 } from "./ccs";
 
 const packageJson = vscode.extensions.getExtension(extensionId).packageJSON;
@@ -1426,6 +1427,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     vscode.commands.registerCommand("vscode-objectscript.ccs.convertCurrentItemCustom", () => {
       sendCommandTelemetryEvent("convertCurrentItemCustom");
       void convertCurrentItemCustom();
+    }),
+    vscode.commands.registerCommand("vscode-objectscript.ccs.analizarVersaoItem", () => {
+      sendCommandTelemetryEvent("analizarVersaoItem");
+      void analizarVersaoItem();
     }),
     vscode.commands.registerCommand("vscode-objectscript.serverCommands.sourceControl", (uri?: vscode.Uri) => {
       sendCommandTelemetryEvent("serverCommands.sourceControl");


### PR DESCRIPTION
Introduces a new command for analyzing item versions, enhancing Consistem workflow support. Updates command registration, UI contributions, and routing to enable easy access and execution from the editor.

This PR fixes #