### PR TITLE
feat: Adds flag to control display of non-converted lines

### DIFF
--- a/src/ccs/commands/converterItem.ts
+++ b/src/ccs/commands/converterItem.ts
@@ -83,6 +83,7 @@ export async function convertCurrentItemCustom(): Promise<void> {
 
     const payload: ConverterCustomRequestBody = {
       item,
+      flgDisplayLinasNaoConv: 1,
       tipoConversao,
       flgPersistencia,
       flgEliminarCSMV,
@@ -110,7 +111,7 @@ export async function convertCurrentItemOnSave(document: vscode.TextDocument): P
   }
 
   await waitForCompileBeforeAutoConvert(document);
-  await convertDocumentItem(document, "Falha ao converter item automaticamente ao salvar.", true);
+  await convertDocumentItem(document, "Falha ao converter item automaticamente ao salvar.", true, 0);
 }
 
 async function waitForCompileBeforeAutoConvert(document: vscode.TextDocument): Promise<void> {
@@ -124,12 +125,13 @@ async function waitForCompileBeforeAutoConvert(document: vscode.TextDocument): P
 async function convertDocumentItem(
   document: vscode.TextDocument,
   errorMessage: string,
-  silentError = false
+  silentError = false,
+  flgDisplayLinasNaoConv: 0 | 1 = 1
 ): Promise<void> {
   const item = getItemName(document);
 
   try {
-    const responseText = await sharedClient.convertDefault(document, item);
+    const responseText = await sharedClient.convertDefault(document, item, flgDisplayLinasNaoConv);
     renderConversionOutput(responseText);
   } catch (error) {
     if (silentError) {

--- a/src/ccs/sourcecontrol/clients/converterClient.ts
+++ b/src/ccs/sourcecontrol/clients/converterClient.ts
@@ -11,6 +11,7 @@ const ALLOWED_FLAGS = new Set(["agrupSetPiece", "objDynamic"]);
 
 export interface ConverterRequestBody {
   item: string;
+  flgDisplayLinasNaoConv: 0 | 1;
 }
 
 export interface ConverterCustomRequestBody extends ConverterRequestBody {
@@ -27,6 +28,7 @@ export interface ConverterCoreParams {
   flgEliminarCSMV?: number;
   strFlagsConv?: string;
   strParamPersist?: string;
+  flgDisplayLinasNaoConv?: 0 | 1;
 }
 
 export class ConverterClient {
@@ -39,10 +41,11 @@ export class ConverterClient {
   public async convertDefault(
     document: vscode.TextDocument,
     item: string,
+    flgDisplayLinasNaoConv: 0 | 1 = 1,
     token?: vscode.CancellationToken
   ): Promise<string> {
     this.validateItem(item);
-    return this.converterCore(document, item, {}, token);
+    return this.converterCore(document, item, { flgDisplayLinasNaoConv }, token);
   }
 
   public async convertCustom(
@@ -76,6 +79,7 @@ export class ConverterClient {
 
     const body: ConverterRequestBody | ConverterCustomRequestBody = {
       item,
+      flgDisplayLinasNaoConv: params.flgDisplayLinasNaoConv ?? 0,
       ...(this.hasCustomParams(params)
         ? {
             tipoConversao: params.tipoConversao ?? 0,


### PR DESCRIPTION
Introduces a parameter to manage the visibility of non-converted lines during item conversion, providing more granular control over output. Ensures the flag is consistently passed through all related functions and client calls.

This PR fixes #